### PR TITLE
Update SQL Version Call

### DIFF
--- a/src/Http/Controllers/VersionController.php
+++ b/src/Http/Controllers/VersionController.php
@@ -31,8 +31,8 @@ class VersionController
             return 'Unkown';
         }
 
-        $results = DB::select(DB::raw("select version()"));
+        $results = DB::select(DB::raw("select version() as version"));
 
-        return $results[0]->{'version()'};
+        return $results[0]->version;
     }
 }


### PR DESCRIPTION
This is causing an issue for Postgres, when you select `version()`, its returning the result as `version`. Setting the `as` on the statement fixes this issue.